### PR TITLE
Show all columns

### DIFF
--- a/aas_editor/widgets/treeview.py
+++ b/aas_editor/widgets/treeview.py
@@ -81,6 +81,11 @@ class HeaderView(QHeaderView):
             self.addAction(act)
             self.sectionActions[section] = act
 
+    def showAllSections(self):
+        """Show all section except first"""
+        for i in range(1, self.count()):
+            self.showSection(i)
+
     def hideAllSections(self):
         """Hide all section except first"""
         for i in range(1, self.count()):

--- a/aas_editor/widgets/treeview_pack.py
+++ b/aas_editor/widgets/treeview_pack.py
@@ -76,6 +76,7 @@ class PackHeaderView(HeaderView):
             showColumns4typeMenu.addAction(showColumnsAct)
 
         showColumnsListMenu = self.menu.addMenu("Show custom column list")
+        showColumnsListMenu.setToolTip("To manage custom lists, edit custom_column_lists.json")
         for listname in self.customLists:
             sectionNames = self.customLists[listname]
             showColumnsAct = QAction(f"{listname}", self,
@@ -86,11 +87,18 @@ class PackHeaderView(HeaderView):
             showColumnsListMenu.addAction(showColumnsAct)
 
         self.menu.addSeparator()
-        unchooseAllAct = QAction("Hide all columns", self,
-                                 toolTip="Hide all columns",
-                                 statusTip="Hide all columns",
-                                 triggered=lambda: self.hideAllSections())
-        self.menu.addAction(unchooseAllAct)
+
+        showAllColAct = QAction("Show all columns", self,
+                                toolTip="Show all columns",
+                                statusTip="Show all columns",
+                                triggered=lambda: self.showAllSections())
+        self.menu.addAction(showAllColAct)
+
+        hideAllColAct = QAction("Hide all columns", self,
+                                toolTip="Hide all columns",
+                                statusTip="Hide all columns",
+                                triggered=lambda: self.hideAllSections())
+        self.menu.addAction(hideAllColAct)
 
     def onShowListOfSectionsAct(self):
         action: QAction = self.sender()

--- a/custom_column_lists.json
+++ b/custom_column_lists.json
@@ -1,4 +1,5 @@
 {
   "example_list": ["value", "value_type", "category", "description", "semantic_id", "id_short", "type"],
-  "example_list2": ["type", "typehint"]
+  "example_list2": ["type", "typehint"],
+  "all_columns": ["unit", "value_type", "entity_type", "first", "asset_identification_model", "value_format", "asset", "output_variable", "data_type", "qualifier", "contained_element", "symbol", "preferred_name", "submodel", "value_list", "id_short", "max", "concept_description", "bill_of_material", "description", "kind", "in_output_variable", "unit_id", "administration", "level_types", "second", "min", "source_of_definition", "value_id", "semantic_id", "input_variable", "value", "derived_from", "category", "is_case_of", "mime_type", "definition", "short_name", "identification", "observed"]
 }


### PR DESCRIPTION
Add an option to show all possible columns in Treeview. The Action is similar to hideAllColAct. 
Small name changes for QActions.